### PR TITLE
client: Fix endianness test

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -28,7 +28,7 @@ static void secure_zero_memory(void* ptr, size_t len)
 static uint32_t big_endian32(uint32_t x)
 {
     uint32_t x_be = x;
-#ifndef BIG_ENDIAN
+#if defined(LITTLE_ENDIAN) && BYTE_ORDER == LITTLE_ENDIAN
     x_be = (x_be & 0x0000ffff) << 16 | (x_be & 0xffff0000) >> 16;
     x_be = (x_be & 0x00ff00ff) <<  8 | (x_be & 0xff00ff00) >>  8;
 #endif


### PR DESCRIPTION
BIG_ENDIAN may be defined even on little endian machines. Fix the test
by checking whether LITTLE_ENDIAN is defined and if it is whether it
matches the byte order.